### PR TITLE
docs: fix simple typo, serveral -> several

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ What does it do?
 
 A terminal multiplexer makes it possible to run multiple applications in the
 same terminal. It does this by emulating a vt100 terminal for each application.
-There are serveral programs doing this. The most famous are `GNU Screen
+There are several programs doing this. The most famous are `GNU Screen
 <https://www.gnu.org/software/screen/>`_ and `tmux <https://tmux.github.io/>`_.
 
 Pymux is written entirely in Python. It doesn't need any C extension. It runs


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `several` rather than `serveral`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md